### PR TITLE
[Hotfix] 修復todolist的add模式，於輸入五個參數的狀況下不會儲存detail的問題

### DIFF
--- a/ToDoList/todolist/operate_list.py
+++ b/ToDoList/todolist/operate_list.py
@@ -25,7 +25,7 @@ def operate_list(server, info, args):
             'creator': info.player,
             'time': time.strftime('%Y-%m-%d %H:%M'),
             'tags':tag_list,
-            'detail': [args[3] if len(args) == 4 else ''],
+            'detail': [args[3] if len(args) in [4, 5] else ''],
             'progress': args[4] if len(args) == 5 else ''
         }
         fun.save()


### PR DESCRIPTION
- 修復todolist的add模式，於輸入五個參數的狀況下不會儲存detail的問題
- 提醒發布時記得修改config來進行進版